### PR TITLE
Npm publish code : fixed unnecessary object creation and more

### DIFF
--- a/src/Select2.vue
+++ b/src/Select2.vue
@@ -73,10 +73,8 @@ export default {
         data: this.options
       })
       .on('select2:select select2:unselect', ev => {
-        const { id, text, selected } = ev['params']['data'];
-        const selectValue = this.select2.val();
-        this.$emit('change', selectValue);
-        this.$emit('select', { id, text, selected });
+        this.$emit('change', this.select2.val());
+        this.$emit('select', ev['params']['data']);
       });
     this.setValue(this.value);
   },


### PR DESCRIPTION
Fixed unnecessary object creation.
The most important part is when selected object is more then id and text like : `{id : 1, text : 'text', status : 'active', is_admin: 1}` so `@select` event they can access the complete object instead of finding again those object.
 