### PR TITLE
Fixed a bug with the placeholder

### DIFF
--- a/src/Select2.vue
+++ b/src/Select2.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <select class="form-control" :id="id" :name="name" :placeholder="placeholder" :disabled="disabled" :required="required"></select>
+    <select class="form-control" :id="id" :name="name" :disabled="disabled" :required="required"></select>
   </div>
 </template>
 
@@ -31,7 +31,7 @@ export default {
     },
     placeholder: {
       type: String,
-      default: ''
+      default: 'vue-select2'
     },
     options: {
       type: Array,
@@ -63,6 +63,7 @@ export default {
     setOption(val = []) {
       this.select2.empty();
       this.select2.select2({
+        placeholder: this.placeholder,
         ...this.settings,
         data: val
       });
@@ -81,6 +82,7 @@ export default {
     this.select2 = $(this.$el)
       .find('select')
       .select2({
+        placeholder: this.placeholder,
         ...this.settings,
         data: this.options
       })


### PR DESCRIPTION
**With the current setup of the placeholder, the "allowClear" setting of select2 does not work.** The reason is that **the "allowClear" required a placeholder setted via js**. In the way you are setting the placeholder (on the select tag), the select2 js can't find it.
If you compare the html (between the current and my version) you can see the difference. With my fix you can see that there's two point where the placeholder is set; one in the select tag (like the current version) and one in a span tag below.

Sorry for my bad english, I hope you understand the issue.