### PR TITLE
Update Select2.vue

### DIFF
--- a/src/Select2.vue
+++ b/src/Select2.vue
@@ -6,7 +6,7 @@
 
 <script>
 import $ from 'jquery';
-import 'select2/dist/js/select2.full';
+import 'select2/dist/js/select2';
 import 'select2/dist/css/select2.min.css'
 
 export default {


### PR DESCRIPTION
For reason, some users don't need includes jquery.mousewheel, so to avoid some bug related to jquery.mousewheel (include me). We should just include standard version select2 library