### PR TITLE
fixed "SyntaxError: The requested module '/jquery/dist/jquery.js' does not provide an export named default"

### DIFF
--- a/src/Select2.vue
+++ b/src/Select2.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import $ from 'jquery';
+import * as jQuery from 'jquery';
 import 'select2/dist/js/select2.full';
 import 'select2/dist/css/select2.min.css'
 


### PR DESCRIPTION
jquery.js module must have export default function, if it is need to import like this `import $ from 'jquery';`, but jquery does not have export default function. 
In this pull request I added other way to use jquery: `import * as Jquery from 'jquery';`, which load module to Jquery variable.

Another way can be to use separated file (says, named jquery_compat.js), like this:
```
import 'jquery.js';
export default window.jQuery.noConflict(true);
```

And in Select2.vue to use:

```
import $ from "./jquery_compat.js";
```

If it need I will fix my pull request with second way of bug solution.

Using `import * as Jquery from 'jquery';` is a bit ugly way in my opinion, because we cannot use jQuery.noConflict. But I don't know another way to fix this bug. If anyone knows a better fix than both above, please comment.